### PR TITLE
Adicionando favicon em Svg. #2

### DIFF
--- a/apoio/apoio/templates/apoio/header.html
+++ b/apoio/apoio/templates/apoio/header.html
@@ -44,9 +44,11 @@
 	<meta name="twitter:image:alt" content="Liberte a Democracia - Partido Pirata" />
 
     <!-- favicon -->
-    <link rel="shortcut icon" href="" />
-    <link rel="icon" href="{% static "/img/favicon.ico" %}" type="image/x-icon" />
-
+    	<link rel="shortcut icon" href="http://partidopirata.org/wp-content/themes/piratenkleider/favicon.ico">
+    	<!-- 404: <link rel="icon" href="{% static "/img/favicon.ico" %}" type="image/x-icon" /> -->
+    	<!-- Favicon in svg for Firefox -->
+    	<link rel="icon" type="image/svg+xml" href="{% static "/logo.pirata.svg" %}">
+    
     <!-- The excelent http://helpers.araujo.cc plus our own CSS overlay -->
     <link rel="stylesheet" href="{% static "/static/css/fonts.css" %}" />
     <link rel="stylesheet" href="{% static "/static/css/helpers.min.css" %}" />


### PR DESCRIPTION
O antigo favicon não está sendo encontrado. https://apoio.partidopirata.org/static/favicon.ico 
Mas favicon em svg apenas funciona no Firefox (http://caniuse.com/#feat=link-icon-svg) e o favicon do partidopirata.org (http://partidopirata.org/wp-content/themes/piratenkleider/favicon.ico) está sem composição alpha.
